### PR TITLE
Add support for passing multiple repositories at once to clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ export GOOGLE_CLOUD_PROJECT=[PROJECT_NAME]
 ### Running `mozilla-linux-pkg-manager`
 To run `mozilla-linux-pkg-manager`, use uv with the following command:
 ```bash
-uv run mozilla-linux-pkg-manager clean-up [-h] --product PRODUCT --repository REPOSITORY --region REGION --retention-days RETENTION_DAYS [--dry-run]
+uv run mozilla-linux-pkg-manager clean-up [-h] --package PACKAGE --repository REPOSITORY [REPOSITORY ...] --region REGION --retention-days RETENTION_DAYS [--dry-run]
 ```
 
 #### Parameters
 - `--package`: A regular expression matching the name of the packages to clean-up.
 - `--retention-days`: Sets the retention period in days for packages that match the `package` regex.
 - `--dry-run`: Tells the script to do a no-op run and print out a summary of the operations that will be executed.
-- `--repository`: The repository to perform maintenance operations on.
+- `--repository`: One or more repositories to perform maintenance operations on.
 - `--region`: The cloud region the repository is hosted in.
 
 #### Examples

--- a/src/mozilla_linux_pkg_manager/cli.py
+++ b/src/mozilla_linux_pkg_manager/cli.py
@@ -77,9 +77,9 @@ async def batch_delete_versions(targets, args):
     )
 
 
-async def get_repository(args):
+async def get_repository(region, repository_name):
     client = artifactregistry_v1.ArtifactRegistryAsyncClient()
-    parent = f"projects/{os.environ['GOOGLE_CLOUD_PROJECT']}/locations/{args.region}/repositories/{args.repository}"
+    parent = f"projects/{os.environ['GOOGLE_CLOUD_PROJECT']}/locations/{region}/repositories/{repository_name}"
     get_repository_request = artifactregistry_v1.GetRepositoryRequest(
         name=parent,
     )
@@ -122,12 +122,6 @@ async def list_versions(package):
 
 
 async def clean_up(args):
-    logging.info("Pinging repository...")
-    repository = await get_repository(args)
-    logging.info(
-        f"Found repository:\nrepository = {json.dumps(artifactregistry_v1.Repository.to_dict(repository), indent=4)}"
-    )
-    packages = await list_packages(repository)
     now = datetime.now(UTC)
     targets = defaultdict(set)
     pattern = re.compile(args.package)
@@ -136,16 +130,24 @@ async def clean_up(args):
 
     start = time.time()
 
-    async for package in packages:
-        name = os.path.basename(package.name)
-        if pattern.match(name):
-            logging.info(f"Looking for expired package versions of {name}...")
-            versions = await list_versions(package)
-            async for version in versions:
-                all_versions.add(version.name)
-                if now - version.create_time > timedelta(days=args.retention_days):
-                    targets[package.name].add(version.name)
-                    unique_expired_versions.add(os.path.basename(version.name))
+    for repository_name in args.repository:
+        logging.info(f"Pinging repository '{repository_name}'...")
+        repository = await get_repository(args.region, repository_name)
+        logging.info(
+            f"Found repository:\nrepository = {json.dumps(artifactregistry_v1.Repository.to_dict(repository), indent=4)}"
+        )
+        packages = await list_packages(repository)
+
+        async for package in packages:
+            name = os.path.basename(package.name)
+            if pattern.match(name):
+                logging.info(f"Looking for expired package versions of {name}...")
+                versions = await list_versions(package)
+                async for version in versions:
+                    all_versions.add(version.name)
+                    if now - version.create_time > timedelta(days=args.retention_days):
+                        targets[package.name].add(version.name)
+                        unique_expired_versions.add(os.path.basename(version.name))
 
     end = time.time()
     elapsed = int(end - start)
@@ -205,7 +207,8 @@ def main():
     clean_up_parser.add_argument(
         "--repository",
         type=str,
-        help="",
+        nargs="+",
+        help="One or more repository names to clean up",
         required=True,
     )
     clean_up_parser.add_argument(


### PR DESCRIPTION
This was pretty straightforward because targets already contains the parent for the package which includes the repo so all we have to do is iterate over repos and then packages instead of just packages.

Most of this is just new tests to make sure that the batch deletion deletes the right package in the right repository.